### PR TITLE
Improved item spawn

### DIFF
--- a/Assets/ProceduralTileMapGenerator/Scripts/MapGenerator.cs
+++ b/Assets/ProceduralTileMapGenerator/Scripts/MapGenerator.cs
@@ -163,14 +163,27 @@ public class MapGenerator : MonoBehaviour
     //ToDo: Implementieren, dass items nicht auf der gleichen stelle spawnen
     private void SpawnItems(Dictionary<VoronoiPoint, List<Vector2>> regions)
     {
+        Dictionary<ItemSpawn, float> extraSpawnBuffer = new Dictionary<ItemSpawn, float>();
         foreach(var region in regions)
         {
             TileType tileType = TileTypes[region.Key.TileIndex-1];
             foreach (var item in tileType.UniqueItemsForTileType) {
                 float spawnCountInRegion = (float)(region.Value.Count / (float)SquareSize) * item.ItemSpawnCountPerSquareSize;
-                spawnCountInRegion = Mathf.RoundToInt(spawnCountInRegion);
+                int spawnCountInRegionRounded = Mathf.RoundToInt(spawnCountInRegion);
+                if (!extraSpawnBuffer.ContainsKey(item))
+                    extraSpawnBuffer.Add(item, 0);
 
-                for (int i = 0; i < spawnCountInRegion; i++)
+                extraSpawnBuffer[item] += spawnCountInRegion - spawnCountInRegionRounded;
+
+                if(spawnCountInRegion % 1 < 0.5f && extraSpawnBuffer[item] >= 1 - (spawnCountInRegion % 1))
+                {
+                    spawnCountInRegionRounded++;
+                    extraSpawnBuffer[item] -= 1 - (spawnCountInRegion % 1);
+                }
+
+                if (spawnCountInRegionRounded > region.Value.Count)
+                    spawnCountInRegionRounded -= spawnCountInRegionRounded - (int)spawnCountInRegion;
+                for (int i = 0; i < spawnCountInRegionRounded; i++)
                 {
                     bool spawned = false;
                     Vector2 randomSpawnLocation = new Vector2();

--- a/Assets/ProceduralTileMapGenerator/Scripts/VoronoiMap.cs
+++ b/Assets/ProceduralTileMapGenerator/Scripts/VoronoiMap.cs
@@ -6,6 +6,7 @@ public class VoronoiMap {
 
     Lottery<Number> lottery = new Lottery<Number>();
     private VoronoiPoint[] voronoiPoints;
+    private Dictionary<VoronoiPoint, List<Vector2>> regions;
 
     public VoronoiMap(TileType[] tileTypes)
     {
@@ -15,10 +16,13 @@ public class VoronoiMap {
         }
     }
 
-    public byte[,] GenerateMap(int mapWidth, int mapHeight, int pointCount)
+    public byte[,] GenerateMap(int mapWidth, int mapHeight, int pointCount, out Dictionary<VoronoiPoint, List<Vector2>> regions)
     {
+        this.regions = new Dictionary<VoronoiPoint, List<Vector2>>();
         GenerateVoronoiPoints(mapWidth, mapHeight, pointCount);
-        return GenerateByteMap(mapWidth, mapHeight);
+        byte[,] map = GenerateByteMap(mapWidth, mapHeight);
+        regions = this.regions;
+        return map;
     }
     
     private void GenerateVoronoiPoints(int mapWidth, int mapHeight, int pointCount)
@@ -63,7 +67,12 @@ public class VoronoiMap {
         {
             for (int y = 0; y < mapHeight; y++)
             {
-                map[x, y] = NearestVoronoiPoint(x, y).TileIndex;
+                VoronoiPoint nearestVP = NearestVoronoiPoint(x, y);
+                map[x, y] = nearestVP.TileIndex;
+                if (!regions.ContainsKey(nearestVP))
+                    regions.Add(nearestVP, new List<Vector2>());
+
+                regions[nearestVP].Add(new Vector2(x, y));
             }
         }
 
@@ -97,7 +106,7 @@ class Number
     public byte Index;
 }
 
-class VoronoiPoint
+public class VoronoiPoint
 {
     public int X, Y;
     public byte TileIndex;

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -14147,7 +14147,7 @@ Prefab:
     - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
         type: 2}
       propertyPath: TileTypes.Array.data[1].UniqueItemsForTileType.Array.data[0].ItemSpawnCountPerSquareSize
-      value: 1
+      value: 1.5
       objectReference: {fileID: 0}
     - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
         type: 2}
@@ -16224,7 +16224,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: -0.000066259716, y: 0.00009253925}
+  m_AnchoredPosition: {x: 0.00000068762523, y: 0.00009253925}
   m_SizeDelta: {x: 254.2, y: 398.6}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &1504368677

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -5746,8 +5746,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1203390478}
   m_HandleRect: {fileID: 1203390477}
   m_Direction: 2
-  m_Value: 1
-  m_Size: 0.5621426
+  m_Value: 0.99999946
+  m_Size: 0.5621425
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -13755,6 +13755,11 @@ Prefab:
     m_Modifications:
     - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
         type: 2}
+      propertyPath: TileTypes.Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
       propertyPath: ItemSpawns.Array.size
       value: 0
       objectReference: {fileID: 0}
@@ -13771,6 +13776,21 @@ Prefab:
     - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
         type: 2}
       propertyPath: TileTypes.Array.data[2].UniqueItemForTileType.Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[0].UniqueItemsForTileType.Array.size
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[1].UniqueItemsForTileType.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[2].UniqueItemsForTileType.Array.size
       value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 4102341729883800, guid: 7b68f2bd3cf4204438916440ac238b13, type: 2}
@@ -13828,19 +13848,19 @@ Prefab:
         type: 2}
       propertyPath: TileTypes.Array.data[0].TypeSprite
       value: 
-      objectReference: {fileID: 21300000, guid: 29a77aeb8962fa64ea30a957ad8891da,
+      objectReference: {fileID: 21300000, guid: c06a10dd8d388b8458f9b57ad5064420,
         type: 3}
     - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
         type: 2}
       propertyPath: TileTypes.Array.data[1].TypeSprite
       value: 
-      objectReference: {fileID: 21300000, guid: 174a4e1c61942a9478683e3346eb833c,
+      objectReference: {fileID: 21300000, guid: a2648ce0aefb82348b88eb154af22487,
         type: 3}
     - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
         type: 2}
       propertyPath: TileTypes.Array.data[2].TypeSprite
       value: 
-      objectReference: {fileID: 21300000, guid: 3213fdf52c453094799eb1dfbf690701,
+      objectReference: {fileID: 21300000, guid: 488c6924eba0ca64983d5fd019f9b60a,
         type: 3}
     - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
         type: 2}
@@ -14021,9 +14041,182 @@ Prefab:
       propertyPath: Tilemap
       value: 
       objectReference: {fileID: 1521558636}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: spriteGroesse
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[0].Weight
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[1].Weight
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[2].Weight
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[3].Weight
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: BorderSprite
+      value: 
+      objectReference: {fileID: 21300000, guid: a3ccf8d83ca108542839513f6c3ff5fa,
+        type: 3}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: tile
+      value: 
+      objectReference: {fileID: 1054342790953782, guid: 73cc97ba0cf1c4a4ca428a675a2edbab,
+        type: 2}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: parent
+      value: 
+      objectReference: {fileID: 1279046483}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[0].UniqueItemsForTileType.Array.data[0].ItemPrefab
+      value: 
+      objectReference: {fileID: 1912465542056280, guid: d36668bbe882ebb479330856950c2088,
+        type: 2}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[0].UniqueItemsForTileType.Array.data[0].ItemSpawnCountPerSquareSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[0].UniqueItemsForTileType.Array.data[1].ItemPrefab
+      value: 
+      objectReference: {fileID: 1117359519937690, guid: 660f06d6a50b1784d864c45f5676ffb6,
+        type: 2}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[0].UniqueItemsForTileType.Array.data[1].ItemSpawnCountPerSquareSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[0].UniqueItemsForTileType.Array.data[2].ItemPrefab
+      value: 
+      objectReference: {fileID: 1874344005813358, guid: 2fda8b98d4b44df498a9483b7ba19e43,
+        type: 2}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[0].UniqueItemsForTileType.Array.data[2].ItemSpawnCountPerSquareSize
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[0].UniqueItemsForTileType.Array.data[3].ItemPrefab
+      value: 
+      objectReference: {fileID: 1681146356570238, guid: f1064bf9ff025c34aabf696ac8537754,
+        type: 2}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[0].UniqueItemsForTileType.Array.data[3].ItemSpawnCountPerSquareSize
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[0].UniqueItemsForTileType.Array.data[4].ItemPrefab
+      value: 
+      objectReference: {fileID: 1294765828837984, guid: 42a12f9c2cfba3e4fa54cde722259c75,
+        type: 2}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[0].UniqueItemsForTileType.Array.data[4].ItemSpawnCountPerSquareSize
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[1].UniqueItemsForTileType.Array.data[0].ItemPrefab
+      value: 
+      objectReference: {fileID: 1947398072653710, guid: ac6c6b6f9d689fb4b89a0b9ce1cc791c,
+        type: 2}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[1].UniqueItemsForTileType.Array.data[0].ItemSpawnCountPerSquareSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[1].UniqueItemsForTileType.Array.data[1].ItemPrefab
+      value: 
+      objectReference: {fileID: 1900411404758288, guid: e199b5ec8610dcd4d9af73a06ccdbc6d,
+        type: 2}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[1].UniqueItemsForTileType.Array.data[1].ItemSpawnCountPerSquareSize
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[2].UniqueItemsForTileType.Array.data[0].ItemPrefab
+      value: 
+      objectReference: {fileID: 1636630041070194, guid: 9c17ad9a63ad7704fbccbdde5a448c72,
+        type: 2}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[2].UniqueItemsForTileType.Array.data[0].ItemSpawnCountPerSquareSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[2].UniqueItemsForTileType.Array.data[1].ItemPrefab
+      value: 
+      objectReference: {fileID: 1090251121453786, guid: 3c9d2d252839bce40886460663a52b8c,
+        type: 2}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[2].UniqueItemsForTileType.Array.data[1].ItemSpawnCountPerSquareSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[2].UniqueItemsForTileType.Array.data[2].ItemPrefab
+      value: 
+      objectReference: {fileID: 1982929197374292, guid: ba36c121443b88049bd2164919c802cc,
+        type: 2}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[2].UniqueItemsForTileType.Array.data[2].ItemSpawnCountPerSquareSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[2].UniqueItemsForTileType.Array.data[3].ItemPrefab
+      value: 
+      objectReference: {fileID: 1994094433296530, guid: 6487a856d9e4a584abc538498f735807,
+        type: 2}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: TileTypes.Array.data[2].UniqueItemsForTileType.Array.data[3].ItemSpawnCountPerSquareSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114642249156490456, guid: 7b68f2bd3cf4204438916440ac238b13,
+        type: 2}
+      propertyPath: SquareSize
+      value: 150
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 7b68f2bd3cf4204438916440ac238b13, type: 2}
   m_IsPrefabParent: 0
+--- !u!4 &1279046483 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 4390242469405884, guid: 7b68f2bd3cf4204438916440ac238b13,
+    type: 2}
+  m_PrefabInternal: {fileID: 1279046482}
 --- !u!1 &1279590706
 GameObject:
   m_ObjectHideFlags: 0
@@ -16031,7 +16224,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: -0.000022085449, y: 0.000030517578}
+  m_AnchoredPosition: {x: -0.000066259716, y: 0.00009253925}
   m_SizeDelta: {x: 254.2, y: 398.6}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &1504368677
@@ -16748,12 +16941,12 @@ Prefab:
     - target: {fileID: 224882201736003324, guid: e25215d3567895540b3a01078e647082,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 1267.05
+      value: 249.58527
       objectReference: {fileID: 0}
     - target: {fileID: 224882201736003324, guid: e25215d3567895540b3a01078e647082,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -684.925
+      value: -9.924999
       objectReference: {fileID: 0}
     - target: {fileID: 224882201736003324, guid: e25215d3567895540b3a01078e647082,
         type: 2}
@@ -16778,12 +16971,12 @@ Prefab:
     - target: {fileID: 224985102468685806, guid: e25215d3567895540b3a01078e647082,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 1206.9
+      value: 189.43527
       objectReference: {fileID: 0}
     - target: {fileID: 224985102468685806, guid: e25215d3567895540b3a01078e647082,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -684.925
+      value: -9.924999
       objectReference: {fileID: 0}
     - target: {fileID: 224985102468685806, guid: e25215d3567895540b3a01078e647082,
         type: 2}
@@ -16808,12 +17001,12 @@ Prefab:
     - target: {fileID: 224340146211301992, guid: e25215d3567895540b3a01078e647082,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 1507.65
+      value: 490.18527
       objectReference: {fileID: 0}
     - target: {fileID: 224340146211301992, guid: e25215d3567895540b3a01078e647082,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -684.925
+      value: -9.924999
       objectReference: {fileID: 0}
     - target: {fileID: 224340146211301992, guid: e25215d3567895540b3a01078e647082,
         type: 2}
@@ -16838,12 +17031,12 @@ Prefab:
     - target: {fileID: 224830299067764406, guid: e25215d3567895540b3a01078e647082,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 1627.9501
+      value: 610.4853
       objectReference: {fileID: 0}
     - target: {fileID: 224830299067764406, guid: e25215d3567895540b3a01078e647082,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -684.925
+      value: -9.924999
       objectReference: {fileID: 0}
     - target: {fileID: 224830299067764406, guid: e25215d3567895540b3a01078e647082,
         type: 2}
@@ -16868,12 +17061,12 @@ Prefab:
     - target: {fileID: 224894071230537198, guid: e25215d3567895540b3a01078e647082,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 1447.5
+      value: 430.03528
       objectReference: {fileID: 0}
     - target: {fileID: 224894071230537198, guid: e25215d3567895540b3a01078e647082,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -684.925
+      value: -9.924999
       objectReference: {fileID: 0}
     - target: {fileID: 224894071230537198, guid: e25215d3567895540b3a01078e647082,
         type: 2}
@@ -16898,12 +17091,12 @@ Prefab:
     - target: {fileID: 224362706551696510, guid: e25215d3567895540b3a01078e647082,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 1327.2001
+      value: 309.73526
       objectReference: {fileID: 0}
     - target: {fileID: 224362706551696510, guid: e25215d3567895540b3a01078e647082,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -684.925
+      value: -9.924999
       objectReference: {fileID: 0}
     - target: {fileID: 224362706551696510, guid: e25215d3567895540b3a01078e647082,
         type: 2}
@@ -16928,12 +17121,12 @@ Prefab:
     - target: {fileID: 224154295290072002, guid: e25215d3567895540b3a01078e647082,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 1387.35
+      value: 369.88528
       objectReference: {fileID: 0}
     - target: {fileID: 224154295290072002, guid: e25215d3567895540b3a01078e647082,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -684.925
+      value: -9.924999
       objectReference: {fileID: 0}
     - target: {fileID: 224154295290072002, guid: e25215d3567895540b3a01078e647082,
         type: 2}
@@ -16958,12 +17151,12 @@ Prefab:
     - target: {fileID: 224248256847548906, guid: e25215d3567895540b3a01078e647082,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 1567.8
+      value: 550.33527
       objectReference: {fileID: 0}
     - target: {fileID: 224248256847548906, guid: e25215d3567895540b3a01078e647082,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -684.925
+      value: -9.924999
       objectReference: {fileID: 0}
     - target: {fileID: 224248256847548906, guid: e25215d3567895540b3a01078e647082,
         type: 2}


### PR DESCRIPTION
old way of adjusting spawn rate was too complicated.
New version is easier to adjust while improving the performance of the algorithm.

Usage:
two variables are used to adjust the spawn rate.
SquareSize: determents the size of the m² block
ItemSpawnCountPerSquareSize: determents the amount of one item, which is spawned in one block
e.g. whole area is 100 tiles big, SquareSize is set to 50, ItemSpawnCountPerSquareSize is 5
the whole area equals 2 SquareSize, which means that 10 items will be spawned.

The advantage of this implementation is, that the map is scale able, because the item spawn amount is not set for the whole map, but for one Square.